### PR TITLE
feat: 카카오 소셜 로그인 구현

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,66 @@
+import { signJwt } from '@/lib/jwt';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code');
+
+  if (!code) {
+    return NextResponse.json({ error: 'No code provided' }, { status: 400 });
+  }
+
+  const REST_API_KEY = process.env.KAKAO_REST_API_KEY!;
+  const REDIRECT_URI = process.env.KAKAO_REDIRECT_URI!;
+
+  // 인가 코드로 액세스 토큰 요청
+  const tokenResponse = await fetch('https://kauth.kakao.com/oauth/token', {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+    },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: REST_API_KEY,
+      redirect_uri: REDIRECT_URI,
+      code,
+    }),
+  });
+
+  const tokenData = await tokenResponse.json();
+
+  if (tokenData.error) {
+    console.error('토큰 요청 에러', tokenData);
+    return NextResponse.json(tokenData, { status: 400 });
+  }
+
+  // 액세스 토큰으로 사용자 정보 요청
+  const userResponse = await fetch('https://kapi.kakao.com/v2/user/me', {
+    headers: {
+      Authorization: `Bearer ${tokenData.access_token}`,
+      'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+    },
+  });
+
+  const userData = await userResponse.json();
+  const kakaoId = String(userData.id);
+  const nickname = userData.kakao_account?.profile?.nickname ?? '카카오사용자';
+
+  // JWT 만들기
+  const jwt = await signJwt({
+    id: kakaoId,
+    nickname,
+  });
+
+  const response = NextResponse.redirect(new URL('/', request.url));
+
+  response.cookies.set({
+    name: 'auth',
+    value: jwt,
+    httpOnly: true, // JS에서 접근 불가 → XSS 방어
+    path: '/',
+    maxAge: 60 * 60 * 24 * 7, // 7일
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production', // 배포 환경에서만 true
+  });
+
+  return response;
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+// 사용자를 카카오 로그인 페이지로 리다이렉트
+export async function GET() {
+  const REST_API_KEY = process.env.KAKAO_REST_API_KEY!;
+  const REDIRECT_URI = process.env.KAKAO_REDIRECT_URI!;
+
+  const kakaoAuthURL =
+    `https://kauth.kakao.com/oauth/authorize` +
+    `?client_id=${REST_API_KEY}` +
+    `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+    `&response_type=code`;
+
+  return NextResponse.redirect(kakaoAuthURL);
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+
+  response.cookies.set({
+    name: 'auth',
+    value: '',
+    maxAge: 0,
+    path: '/',
+  });
+
+  return response;
+}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -1,6 +1,19 @@
+import { verifyJwt } from '@/lib/jwt';
+import { cookies } from 'next/headers';
 import Link from 'next/link';
+import HeaderAuthSection from './HeaderAuthSection';
 
-export default function Header() {
+export default async function Header() {
+  const token = (await cookies()).get('auth')?.value;
+
+  let nickname: string | null = null;
+
+  if (token) {
+    const payload = await verifyJwt(token);
+    if (payload) {
+      nickname = payload.nickname;
+    }
+  }
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-card/95 backdrop-blur">
       <div className="flex items-center justify-between px-6 py-3">
@@ -12,14 +25,7 @@ export default function Header() {
           </div>
           <span className="text-lg font-bold">스탁두두</span>
         </Link>
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            className="flex items-center gap-2 rounded-full bg-[#FEE500] px-3 py-1.5 text-xs font-semibold text-black active:scale-95 transition"
-          >
-            <span>카카오로 시작하기</span>
-          </button>
-        </div>
+        <HeaderAuthSection nickname={nickname} />
       </div>
     </header>
   );

--- a/components/common/HeaderAuthSection.tsx
+++ b/components/common/HeaderAuthSection.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { User } from 'lucide-react';
+import Link from 'next/link';
+
+type HeaderAuthSectionProps = {
+  nickname: string | null;
+};
+
+export default function HeaderAuthSection({
+  nickname,
+}: HeaderAuthSectionProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/auth/logout', {
+        method: 'POST',
+      });
+      alert('로그아웃이 완료되었습니다.');
+      window.location.reload();
+    } catch (e) {
+      console.error('로그아웃 실패', e);
+    }
+  };
+
+  if (!nickname) {
+    return (
+      <Link href="/api/auth/login">
+        <button
+          type="button"
+          className="flex items-center gap-2 rounded bg-[#FEE500] px-3 py-1.5 text-sm font-semibold text-black active:scale-95 transition cursor-pointer"
+        >
+          <span>카카오 로그인</span>
+        </button>
+      </Link>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">{nickname} 님</span>
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/70 cursor-pointer"
+        >
+          <User className="h-5 w-5 text-white" />
+        </button>
+      </div>
+
+      {open && (
+        <div className="absolute right-0 mt-2 w-40 rounded-md border border-border bg-primary/70 shadow-lg py-2 z-50">
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="w-full px-4 py-2 text-left text-sm cursor-pointer hover:font-semibold"
+          >
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,0 +1,31 @@
+import { SignJWT, jwtVerify } from 'jose';
+
+const SECRET_KEY = new TextEncoder().encode(
+  process.env.JWT_SECRET || 'dev-secret-key-change-this'
+);
+
+export type JwtPayload = {
+  id: string;
+  nickname: string;
+};
+
+// JWT 만들기
+export async function signJwt(payload: JwtPayload) {
+  const token = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt()
+    .setExpirationTime('7d')
+    .sign(SECRET_KEY);
+
+  return token;
+}
+
+// JWT 검증하기
+export async function verifyJwt(token: string) {
+  try {
+    const { payload } = await jwtVerify<JwtPayload>(token, SECRET_KEY);
+    return payload;
+  } catch (err) {
+    console.log(err);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "jose": "^6.1.2",
         "lucide-react": "^0.553.0",
         "next": "16.0.1",
         "react": "19.2.0",
@@ -4719,6 +4720,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.2.tgz",
+      "integrity": "sha512-MpcPtHLE5EmztuFIqB0vzHAWJPpmN1E6L4oo+kze56LIs3MyXIj9ZHMDxqOvkP38gBR7K1v3jqd4WU2+nrfONQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "jose": "^6.1.2",
     "lucide-react": "^0.553.0",
     "next": "16.0.1",
     "react": "19.2.0",


### PR DESCRIPTION
## 📝 변경 사항

1. 카카오 소셜 로그인 구현
2. 헤더 정리

## 🔍 변경 사항 세부 설명

1. 카카오 소셜 로그인 기능 구현 (NextAuth 사용 X)
2. App Router 기반으로 OAuth 인증 → JWT 발급 → httpOnly 쿠키 로그인 유지 흐름 구성
3. 헤더를 서버/클라이언트로 분리하여 로그인 상태 반영
4.  로그아웃 기능 드롭다운 UI 구현

## 📷 스크린샷 (선택)
<img width="1061" height="189" alt="스크린샷 2025-11-19 오후 10 19 40" src="https://github.com/user-attachments/assets/93737be1-a8ac-4d50-aa1e-dd75a826dc5d" />

## 🕵️‍♀️ 요청사항 (선택)
close #7