### PR TITLE
feat: 실시간 종목 차트(국내·해외·전체) API 연동 및 API 구조 리팩터링

### DIFF
--- a/app/api/_kis/KISFetchClient.ts
+++ b/app/api/_kis/KISFetchClient.ts
@@ -1,0 +1,66 @@
+import { getServerAccessToken } from '@/services/kisServerAuth';
+
+const BASE_URL = process.env.KIS_BASE_URL;
+
+type KISMethod = 'GET' | 'POST';
+
+export type KISRequestConfig = {
+  path: string;
+  trId: string;
+  method?: KISMethod;
+  query?: Record<string, string>;
+  body?: unknown;
+};
+
+export async function KISFetchClient<TResponse = unknown>(
+  config: KISRequestConfig
+): Promise<TResponse> {
+  const { path, trId, method = 'GET', query, body } = config;
+
+  const appKey = process.env.KIS_APP_KEY;
+  const appSecret = process.env.KIS_APP_SECRET;
+  const accessToken = await getServerAccessToken();
+
+  if (!appKey || !appSecret) {
+    throw new Error('KIS env not configured');
+  }
+
+  const url = new URL(BASE_URL + path);
+
+  if (query) {
+    const params = new URLSearchParams(query);
+    url.search = params.toString();
+  }
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json; charset=utf-8',
+    authorization: `Bearer ${accessToken}`,
+    appkey: appKey,
+    appsecret: appSecret,
+    tr_id: trId,
+    custtype: 'P',
+  };
+
+  const res = await fetch(url.toString(), {
+    method,
+    headers,
+    cache: 'no-store',
+    body: method === 'POST' ? JSON.stringify(body ?? {}) : undefined,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('KIS request error:', {
+      url: url.toString(),
+      status: res.status,
+      statusText: res.statusText,
+      trId,
+      body: text,
+    });
+    throw new Error(
+      `KIS request failed (${res.status} ${res.statusText}): ${text}`
+    );
+  }
+
+  return (await res.json()) as TResponse;
+}

--- a/app/api/kis/approval/route.ts
+++ b/app/api/kis/approval/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+const BASE_URL = process.env.KIS_BASE_URL;
+
 export async function POST() {
   try {
     const appKey = process.env.KIS_APP_KEY;
@@ -12,8 +14,7 @@ export async function POST() {
       );
     }
 
-    const baseUrl = 'https://openapi.koreainvestment.com:9443';
-    const url = `${baseUrl}/oauth2/Approval`;
+    const url = `${BASE_URL}/oauth2/Approval`;
 
     const res = await fetch(url, {
       method: 'POST',

--- a/app/api/kis/ranking/domestic/route.ts
+++ b/app/api/kis/ranking/domestic/route.ts
@@ -3,12 +3,11 @@ import { getServerAccessToken } from '@/services/kisServerAuth';
 
 const BASE_URL = 'https://openapi.koreainvestment.com:9443';
 
-// 국내 [거대래금],[거래량]
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const metric = searchParams.get('metric') ?? 'amount'; //  amount: 거래대금, volume: 거래량
-    const blng = metric === 'amount' ? '3' : '0'; // 거래량(0), 거래금액(3)
+    type Metric = 'amount' | 'volume' | 'rise' | 'fall';
+    const metric = (searchParams.get('metric') ?? 'amount') as Metric;
 
     const appKey = process.env.KIS_APP_KEY;
     const appSecret = process.env.KIS_APP_SECRET;
@@ -21,21 +20,53 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const params = new URLSearchParams({
-      FID_COND_MRKT_DIV_CODE: 'J',
-      FID_COND_SCR_DIV_CODE: '20171',
-      FID_INPUT_ISCD: '0000',
-      FID_DIV_CLS_CODE: '1', // 분류 구분 코드 - 전체(0), 보통(1), 우선(2)
-      FID_BLNG_CLS_CODE: blng, // 소속 구분 코드 - 평균거래량(0), 거래금액순(3)
-      FID_TRGT_CLS_CODE: '111111111',
-      FID_TRGT_EXLS_CLS_CODE: '1111110001', // 투자위험/관리종목/정리매매/불성실공시/우선주/거래정지/ETF/ETN/신용주문불가/SPAC
-      FID_INPUT_PRICE_1: '',
-      FID_INPUT_PRICE_2: '',
-      FID_VOL_CNT: '',
-      FID_INPUT_DATE_1: '',
-    });
+    let url: string;
+    let trId: string;
 
-    const url = `${BASE_URL}/uapi/domestic-stock/v1/quotations/volume-rank?${params.toString()}`;
+    if (metric === 'amount' || metric === 'volume') {
+      // 거래대금, 거래량
+      const blng = metric === 'amount' ? '3' : '0'; // 거래량(0), 거래금액(3)
+
+      const params = new URLSearchParams({
+        FID_COND_MRKT_DIV_CODE: 'J',
+        FID_COND_SCR_DIV_CODE: '20171',
+        FID_INPUT_ISCD: '0000',
+        FID_DIV_CLS_CODE: '1', // 전체(0), 보통(1), 우선(2)
+        FID_BLNG_CLS_CODE: blng, // 평균거래량(0), 거래금액순(3)
+        FID_TRGT_CLS_CODE: '111111111',
+        FID_TRGT_EXLS_CLS_CODE: '1111110001', // 투자위험/관리종목/정리매매/불성실공시/우선주/거래정지/ETF/ETN/신용주문불가/SPAC
+        FID_INPUT_PRICE_1: '',
+        FID_INPUT_PRICE_2: '',
+        FID_VOL_CNT: '',
+        FID_INPUT_DATE_1: '',
+      });
+
+      url = `${BASE_URL}/uapi/domestic-stock/v1/quotations/volume-rank?${params.toString()}`;
+      trId = 'FHPST01710000';
+    } else {
+      // 급상승, 급하락
+      const isRise = metric === 'rise';
+
+      const params = new URLSearchParams({
+        fid_rsfl_rate2: '',
+        fid_cond_mrkt_div_code: 'J',
+        fid_cond_scr_div_code: '20170',
+        fid_input_iscd: '0000',
+        fid_rank_sort_cls_code: isRise ? '0' : '1',
+        fid_input_cnt_1: '0',
+        fid_prc_cls_code: '1',
+        fid_input_price_1: '',
+        fid_input_price_2: '',
+        fid_vol_cnt: '',
+        fid_trgt_cls_code: '0',
+        fid_trgt_exls_cls_code: '0',
+        fid_div_cls_code: '0',
+        fid_rsfl_rate1: '',
+      });
+
+      url = `${BASE_URL}/uapi/domestic-stock/v1/ranking/fluctuation?${params.toString()}`;
+      trId = 'FHPST01700000';
+    }
 
     const res = await fetch(url, {
       method: 'GET',
@@ -44,7 +75,7 @@ export async function GET(req: NextRequest) {
         authorization: `Bearer ${accessToken}`,
         appkey: appKey,
         appsecret: appSecret,
-        tr_id: 'FHPST01710000',
+        tr_id: trId,
         custtype: 'P',
       },
       cache: 'no-store',
@@ -52,15 +83,14 @@ export async function GET(req: NextRequest) {
 
     if (!res.ok) {
       const text = await res.text();
-      console.error('KIS domestic volume-rank error:', text);
+      console.error('KIS domestic ranking error:', text);
       return NextResponse.json(
-        { message: 'KIS domestic volume-rank request failed', detail: text },
+        { message: 'KIS domestic ranking request failed', detail: text },
         { status: 500 }
       );
     }
 
     const data = await res.json();
-
     return NextResponse.json(data);
   } catch (error) {
     console.error('KIS domestic ranking route error:', error);

--- a/app/api/kis/ranking/domestic/route.ts
+++ b/app/api/kis/ranking/domestic/route.ts
@@ -3,10 +3,11 @@ import { getServerAccessToken } from '@/services/kisServerAuth';
 
 const BASE_URL = 'https://openapi.koreainvestment.com:9443';
 
+type Metric = 'amount' | 'volume' | 'rise' | 'fall';
+
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    type Metric = 'amount' | 'volume' | 'rise' | 'fall';
     const metric = (searchParams.get('metric') ?? 'amount') as Metric;
 
     const appKey = process.env.KIS_APP_KEY;

--- a/app/api/kis/ranking/domestic/route.ts
+++ b/app/api/kis/ranking/domestic/route.ts
@@ -1,7 +1,5 @@
+import { KISFetchClient } from '@/app/api/_kis/KISFetchClient';
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerAccessToken } from '@/services/kisServerAuth';
-
-const BASE_URL = 'https://openapi.koreainvestment.com:9443';
 
 type Metric = 'amount' | 'volume' | 'rise' | 'fall';
 
@@ -10,25 +8,11 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const metric = (searchParams.get('metric') ?? 'amount') as Metric;
 
-    const appKey = process.env.KIS_APP_KEY;
-    const appSecret = process.env.KIS_APP_SECRET;
-    const accessToken = await getServerAccessToken();
-
-    if (!appKey || !appSecret) {
-      return NextResponse.json(
-        { message: 'KIS env not configured' },
-        { status: 500 }
-      );
-    }
-
-    let url: string;
-    let trId: string;
-
+    // 1) 거래대금 / 거래량
     if (metric === 'amount' || metric === 'volume') {
-      // 거래대금, 거래량
       const blng = metric === 'amount' ? '3' : '0'; // 거래량(0), 거래금액(3)
 
-      const params = new URLSearchParams({
+      const query = {
         FID_COND_MRKT_DIV_CODE: 'J',
         FID_COND_SCR_DIV_CODE: '20171',
         FID_INPUT_ISCD: '0000',
@@ -40,63 +24,53 @@ export async function GET(req: NextRequest) {
         FID_INPUT_PRICE_2: '',
         FID_VOL_CNT: '',
         FID_INPUT_DATE_1: '',
+      };
+
+      const data = await KISFetchClient({
+        path: '/uapi/domestic-stock/v1/quotations/volume-rank',
+        trId: 'FHPST01710000',
+        method: 'GET',
+        query,
       });
 
-      url = `${BASE_URL}/uapi/domestic-stock/v1/quotations/volume-rank?${params.toString()}`;
-      trId = 'FHPST01710000';
-    } else {
-      // 급상승, 급하락
-      const isRise = metric === 'rise';
-
-      const params = new URLSearchParams({
-        fid_rsfl_rate2: '',
-        fid_cond_mrkt_div_code: 'J',
-        fid_cond_scr_div_code: '20170',
-        fid_input_iscd: '0000',
-        fid_rank_sort_cls_code: isRise ? '0' : '1',
-        fid_input_cnt_1: '0',
-        fid_prc_cls_code: '1',
-        fid_input_price_1: '',
-        fid_input_price_2: '',
-        fid_vol_cnt: '',
-        fid_trgt_cls_code: '0',
-        fid_trgt_exls_cls_code: '0',
-        fid_div_cls_code: '0',
-        fid_rsfl_rate1: '',
-      });
-
-      url = `${BASE_URL}/uapi/domestic-stock/v1/ranking/fluctuation?${params.toString()}`;
-      trId = 'FHPST01700000';
+      return NextResponse.json(data);
     }
 
-    const res = await fetch(url, {
+    // 2) 급상승 / 급하락
+    const isRise = metric === 'rise';
+
+    const query = {
+      fid_rsfl_rate2: '',
+      fid_cond_mrkt_div_code: 'J',
+      fid_cond_scr_div_code: '20170',
+      fid_input_iscd: '0000',
+      fid_rank_sort_cls_code: isRise ? '0' : '1',
+      fid_input_cnt_1: '0',
+      fid_prc_cls_code: '1',
+      fid_input_price_1: '',
+      fid_input_price_2: '',
+      fid_vol_cnt: '',
+      fid_trgt_cls_code: '0',
+      fid_trgt_exls_cls_code: '0',
+      fid_div_cls_code: '0',
+      fid_rsfl_rate1: '',
+    };
+
+    const data = await KISFetchClient({
+      path: '/uapi/domestic-stock/v1/ranking/fluctuation',
+      trId: 'FHPST01700000',
       method: 'GET',
-      headers: {
-        'content-type': 'application/json; charset=utf-8',
-        authorization: `Bearer ${accessToken}`,
-        appkey: appKey,
-        appsecret: appSecret,
-        tr_id: trId,
-        custtype: 'P',
-      },
-      cache: 'no-store',
+      query,
     });
 
-    if (!res.ok) {
-      const text = await res.text();
-      console.error('KIS domestic ranking error:', text);
-      return NextResponse.json(
-        { message: 'KIS domestic ranking request failed', detail: text },
-        { status: 500 }
-      );
-    }
-
-    const data = await res.json();
     return NextResponse.json(data);
   } catch (error) {
     console.error('KIS domestic ranking route error:', error);
     return NextResponse.json(
-      { message: 'Unexpected error', detail: String(error) },
+      {
+        message: 'KIS domestic ranking route error',
+        detail: String(error),
+      },
       { status: 500 }
     );
   }

--- a/app/api/kis/ranking/overseas/route.ts
+++ b/app/api/kis/ranking/overseas/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerAccessToken } from '@/services/kisServerAuth';
+
+const BASE_URL = 'https://openapi.koreainvestment.com:9443';
+
+type Metric = 'amount' | 'volume' | 'rise' | 'fall';
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const metric = (searchParams.get('metric') ?? 'amount') as Metric;
+
+    const appKey = process.env.KIS_APP_KEY;
+    const appSecret = process.env.KIS_APP_SECRET;
+    const accessToken = await getServerAccessToken();
+
+    if (!appKey || !appSecret) {
+      return NextResponse.json(
+        { message: 'KIS env not configured' },
+        { status: 500 }
+      );
+    }
+
+    let path = '';
+    let trId = '';
+
+    const params = new URLSearchParams({
+      KEYB: '', // NEXT KEY BUFF
+      AUTH: '', // 사용자권한정보
+      EXCD: 'NAS', // 거래소코드 (예: NAS: 나스닥)
+      NDAY: '0', // N일자값 - 0: 당일
+      VOL_RANG: '0', // 거래량조건 - 0: 전체
+    });
+
+    switch (metric) {
+      case 'volume': {
+        path = '/uapi/overseas-stock/v1/ranking/trade-vol';
+        trId = 'HHDFS76310010';
+        params.set('PRC1', '');
+        params.set('PRC2', '');
+        break;
+      }
+      case 'amount': {
+        path = '/uapi/overseas-stock/v1/ranking/trade-pbmn';
+        trId = 'HHDFS76320010';
+        params.set('PRC1', '');
+        params.set('PRC2', '');
+        break;
+      }
+      case 'rise': {
+        path = '/uapi/overseas-stock/v1/ranking/trade-growth';
+        trId = 'HHDFS76330000';
+        break;
+      }
+      case 'fall': {
+        path = '/uapi/overseas-stock/v1/ranking/trade-turnover';
+        trId = 'HHDFS76340000';
+        break;
+      }
+
+      default:
+        return NextResponse.json(
+          { message: `Unsupported metric: ${metric}` },
+          { status: 400 }
+        );
+    }
+
+    const url = `${BASE_URL}${path}?${params.toString()}`;
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        authorization: `Bearer ${accessToken}`,
+        appkey: appKey,
+        appsecret: appSecret,
+        tr_id: trId,
+        custtype: 'P',
+      },
+      cache: 'no-store',
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      console.error(
+        'KIS overseas RAW error:',
+        res.status,
+        res.statusText,
+        text
+      );
+      return NextResponse.json(
+        {
+          message: 'KIS overseas ranking request failed',
+          kisStatus: res.status,
+          kisStatusText: res.statusText,
+          kisBody: text,
+        },
+        { status: 500 }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('KIS overseas ranking route error:', error);
+    return NextResponse.json(
+      { message: 'Unexpected error', detail: String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/kis/ranking/overseas/route.ts
+++ b/app/api/kis/ranking/overseas/route.ts
@@ -1,7 +1,5 @@
+import { KISFetchClient } from '@/app/api/_kis/KISFetchClient';
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerAccessToken } from '@/services/kisServerAuth';
-
-const BASE_URL = 'https://openapi.koreainvestment.com:9443';
 
 type Metric = 'amount' | 'volume' | 'rise' | 'fall';
 
@@ -10,101 +8,74 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const metric = (searchParams.get('metric') ?? 'amount') as Metric;
 
-    const appKey = process.env.KIS_APP_KEY;
-    const appSecret = process.env.KIS_APP_SECRET;
-    const accessToken = await getServerAccessToken();
-
-    if (!appKey || !appSecret) {
-      return NextResponse.json(
-        { message: 'KIS env not configured' },
-        { status: 500 }
-      );
-    }
-
-    let path = '';
-    let trId = '';
-
-    const params = new URLSearchParams({
+    const baseQuery: Record<string, string> = {
       KEYB: '', // NEXT KEY BUFF
       AUTH: '', // 사용자권한정보
       EXCD: 'NAS', // 거래소코드 (예: NAS: 나스닥)
       NDAY: '0', // N일자값 - 0: 당일
       VOL_RANG: '0', // 거래량조건 - 0: 전체
-    });
+    };
+
+    let path = '';
+    let trId = '';
+    let query: Record<string, string> = { ...baseQuery };
 
     switch (metric) {
       case 'volume': {
         path = '/uapi/overseas-stock/v1/ranking/trade-vol';
         trId = 'HHDFS76310010';
-        params.set('PRC1', '');
-        params.set('PRC2', '');
+        query = {
+          ...baseQuery,
+          PRC1: '',
+          PRC2: '',
+        };
         break;
       }
       case 'amount': {
         path = '/uapi/overseas-stock/v1/ranking/trade-pbmn';
         trId = 'HHDFS76320010';
-        params.set('PRC1', '');
-        params.set('PRC2', '');
+        query = {
+          ...baseQuery,
+          PRC1: '',
+          PRC2: '',
+        };
         break;
       }
       case 'rise': {
         path = '/uapi/overseas-stock/v1/ranking/trade-growth';
         trId = 'HHDFS76330000';
+        query = { ...baseQuery };
         break;
       }
       case 'fall': {
         path = '/uapi/overseas-stock/v1/ranking/trade-turnover';
         trId = 'HHDFS76340000';
+        query = { ...baseQuery };
         break;
       }
-
-      default:
+      default: {
         return NextResponse.json(
           { message: `Unsupported metric: ${metric}` },
           { status: 400 }
         );
+      }
     }
 
-    const url = `${BASE_URL}${path}?${params.toString()}`;
-
-    const res = await fetch(url, {
+    const data = await KISFetchClient({
+      path,
+      trId,
       method: 'GET',
-      headers: {
-        'content-type': 'application/json; charset=utf-8',
-        authorization: `Bearer ${accessToken}`,
-        appkey: appKey,
-        appsecret: appSecret,
-        tr_id: trId,
-        custtype: 'P',
-      },
-      cache: 'no-store',
+      query,
     });
 
-    if (!res.ok) {
-      const text = await res.text();
-      console.error(
-        'KIS overseas RAW error:',
-        res.status,
-        res.statusText,
-        text
-      );
-      return NextResponse.json(
-        {
-          message: 'KIS overseas ranking request failed',
-          kisStatus: res.status,
-          kisStatusText: res.statusText,
-          kisBody: text,
-        },
-        { status: 500 }
-      );
-    }
-
-    const data = await res.json();
     return NextResponse.json(data);
   } catch (error) {
     console.error('KIS overseas ranking route error:', error);
     return NextResponse.json(
-      { message: 'Unexpected error', detail: String(error) },
+      {
+        message: 'KIS overseas ranking route error',
+        detail: String(error),
+      },
       { status: 500 }
     );
   }

--- a/app/api/kis/token/route.ts
+++ b/app/api/kis/token/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+const BASE_URL = process.env.KIS_BASE_URL;
+
 export async function POST() {
   try {
     const appKey = process.env.KIS_APP_KEY;
@@ -12,8 +14,7 @@ export async function POST() {
       );
     }
 
-    const baseUrl = 'https://openapi.koreainvestment.com:9443';
-    const url = `${baseUrl}/oauth2/tokenP`;
+    const url = `${BASE_URL}/oauth2/tokenP`;
 
     const res = await fetch(url, {
       method: 'POST',

--- a/components/main/StockTable.tsx
+++ b/components/main/StockTable.tsx
@@ -20,7 +20,6 @@ export default function StockTable({
   metricType,
   onToggleFavorite,
 }: StockTableProps) {
-  console.log(metricType);
   const router = useRouter();
   return (
     <div className="overflow-hidden rounded-xl border border-border/50 bg-card text-card-foreground shadow-sm">
@@ -97,7 +96,7 @@ export default function StockTable({
                             : 'bg-gray-500/10 text-gray-500 hover:bg-gray-500/20'
                       )}
                     >
-                      {stock.changeRate}%
+                      {stock.changeRate.toFixed(2)}%
                     </span>
                   </td>
                   <td className="p-3">

--- a/hooks/useRealtimeStockChart.ts
+++ b/hooks/useRealtimeStockChart.ts
@@ -7,7 +7,7 @@ import {
   fetchDomesticRanking,
 } from '@/services/kisRankingClient';
 
-type RankingMetric = 'amount' | 'volume' | 'rising' | 'falling';
+type RankingMetric = 'amount' | 'volume' | 'rise' | 'fall';
 
 type RegionFilter = '전체' | '국내' | '해외';
 
@@ -28,8 +28,8 @@ function resolveRankingQuery(
   let rankingMetric: RankingMetric | null = null;
   if (metric.includes('거래대금')) rankingMetric = 'amount';
   else if (metric.includes('거래량')) rankingMetric = 'volume';
-  else if (metric.includes('급상승')) rankingMetric = 'rising';
-  else if (metric.includes('급하락')) rankingMetric = 'falling';
+  else if (metric.includes('급상승')) rankingMetric = 'rise';
+  else if (metric.includes('급하락')) rankingMetric = 'fall';
 
   if (!rankingMetric) {
     return {
@@ -49,13 +49,13 @@ function resolveRankingQuery(
     };
   }
 
-  // 국내 급상승 / 급하락
-  if (rankingMetric === 'rising' || rankingMetric === 'falling') {
+  if (rankingMetric === 'rise' || rankingMetric === 'fall') {
+    const apiMetric: DomesticRankingMetric =
+      rankingMetric === 'rise' ? 'rise' : 'fall';
     return {
-      queryKey: ['ranking', 'domestic', rankingMetric],
-      enabled: false,
-      queryFn: async () => [],
-      notImplementedMessage: '국내 급등/급락 순위는 아직 준비 중입니다.',
+      queryKey: ['ranking', 'domestic', apiMetric],
+      enabled: regionFilter === '국내' || regionFilter === '전체',
+      queryFn: () => fetchDomesticRanking(apiMetric),
     };
   }
 

--- a/hooks/useRealtimeStockChart.ts
+++ b/hooks/useRealtimeStockChart.ts
@@ -10,7 +10,7 @@ import {
 } from '@/services/kisRankingClient';
 
 type RegionFilter = '전체' | '국내' | '해외';
-type RankingMetric = DomesticRankingMetric;
+type RankingMetric = 'amount' | 'volume' | 'rise' | 'fall';
 
 type StockRankingItem = DomesticRankingItem;
 

--- a/hooks/useRealtimeStockChart.ts
+++ b/hooks/useRealtimeStockChart.ts
@@ -10,7 +10,7 @@ import {
 } from '@/services/kisRankingClient';
 
 type RegionFilter = '전체' | '국내' | '해외';
-type RankingMetric = 'amount' | 'volume' | 'rise' | 'fall';
+type RankingMetric = DomesticRankingMetric;
 
 type StockRankingItem = DomesticRankingItem;
 
@@ -38,6 +38,14 @@ function formatTime(timestamp: number | null | undefined) {
   return `${h}:${m}`;
 }
 
+function resolveRankingMetric(metricLabel: string): RankingMetric | null {
+  if (metricLabel.includes('거래대금')) return 'amount';
+  if (metricLabel.includes('거래량')) return 'volume';
+  if (metricLabel.includes('급상승')) return 'rise';
+  if (metricLabel.includes('급하락')) return 'fall';
+  return null;
+}
+
 function resolveRankingQuery(
   region: string,
   metricLabel: string
@@ -45,11 +53,7 @@ function resolveRankingQuery(
   const regionFilter: RegionFilter =
     region === '국내' || region === '해외' ? (region as RegionFilter) : '전체';
 
-  let rankingMetric: RankingMetric | null = null;
-  if (metricLabel.includes('거래대금')) rankingMetric = 'amount';
-  else if (metricLabel.includes('거래량')) rankingMetric = 'volume';
-  else if (metricLabel.includes('급상승')) rankingMetric = 'rise';
-  else if (metricLabel.includes('급하락')) rankingMetric = 'fall';
+  const rankingMetric = resolveRankingMetric(metricLabel);
 
   if (!rankingMetric) {
     return {
@@ -60,8 +64,10 @@ function resolveRankingQuery(
     };
   }
 
-  if (regionFilter === '국내' || regionFilter === '전체') {
+  // 국내
+  if (regionFilter === '국내') {
     const apiMetric: DomesticRankingMetric = rankingMetric;
+
     return {
       queryKey: ['ranking', 'domestic', apiMetric],
       enabled: true,
@@ -69,8 +75,10 @@ function resolveRankingQuery(
     };
   }
 
+  // 해외
   if (regionFilter === '해외') {
     const apiMetric: OverseasRankingMetric = rankingMetric;
+
     return {
       queryKey: ['ranking', 'overseas', apiMetric],
       enabled: true,
@@ -78,6 +86,40 @@ function resolveRankingQuery(
     };
   }
 
+  // 전체
+  if (regionFilter === '전체') {
+    const domesticMetric: DomesticRankingMetric = rankingMetric;
+    const overseasMetric: OverseasRankingMetric = rankingMetric;
+
+    return {
+      queryKey: ['ranking', 'all', rankingMetric],
+      enabled: true,
+      queryFn: async () => {
+        const [domestic, overseas] = await Promise.all([
+          fetchDomesticRanking(domesticMetric),
+          fetchOverseasRanking(overseasMetric),
+        ]);
+
+        const combined: StockRankingItem[] = [...domestic, ...overseas];
+
+        switch (rankingMetric) {
+          case 'volume':
+            combined.sort((a, b) => b.volume - a.volume);
+            break;
+          case 'amount':
+            combined.sort((a, b) => b.amount - a.amount);
+            break;
+          case 'rise':
+            combined.sort((a, b) => b.changeRate - a.changeRate);
+            break;
+          case 'fall':
+            combined.sort((a, b) => a.changeRate - b.changeRate);
+            break;
+        }
+        return combined;
+      },
+    };
+  }
   return {
     queryKey: ['ranking', regionFilter, 'unknown'],
     enabled: false,

--- a/hooks/useRealtimeStockChart.ts
+++ b/hooks/useRealtimeStockChart.ts
@@ -4,81 +4,25 @@ import { useQuery } from '@tanstack/react-query';
 import {
   DomesticRankingItem,
   DomesticRankingMetric,
+  OverseasRankingMetric,
   fetchDomesticRanking,
+  fetchOverseasRanking,
 } from '@/services/kisRankingClient';
 
+type RegionFilter = '전체' | '국내' | '해외';
 type RankingMetric = 'amount' | 'volume' | 'rise' | 'fall';
 
-type RegionFilter = '전체' | '국내' | '해외';
+type StockRankingItem = DomesticRankingItem;
 
 type ResolvedRankingQuery = {
   queryKey: (string | RegionFilter | RankingMetric)[];
   enabled: boolean;
-  queryFn: () => Promise<DomesticRankingItem[]>;
+  queryFn: () => Promise<StockRankingItem[]>;
   notImplementedMessage?: string;
 };
 
-function resolveRankingQuery(
-  region: string,
-  metric: string
-): ResolvedRankingQuery {
-  const regionFilter: RegionFilter =
-    region === '국내' || region === '해외' ? (region as RegionFilter) : '전체';
-
-  let rankingMetric: RankingMetric | null = null;
-  if (metric.includes('거래대금')) rankingMetric = 'amount';
-  else if (metric.includes('거래량')) rankingMetric = 'volume';
-  else if (metric.includes('급상승')) rankingMetric = 'rise';
-  else if (metric.includes('급하락')) rankingMetric = 'fall';
-
-  if (!rankingMetric) {
-    return {
-      queryKey: ['ranking', regionFilter, 'unknown'],
-      enabled: false,
-      queryFn: async () => [],
-      notImplementedMessage: '선택한 지표는 아직 준비 중입니다.',
-    };
-  }
-
-  if (rankingMetric === 'amount' || rankingMetric === 'volume') {
-    const apiMetric: DomesticRankingMetric = rankingMetric;
-    return {
-      queryKey: ['ranking', 'domestic', apiMetric],
-      enabled: true,
-      queryFn: () => fetchDomesticRanking(apiMetric),
-    };
-  }
-
-  if (rankingMetric === 'rise' || rankingMetric === 'fall') {
-    const apiMetric: DomesticRankingMetric =
-      rankingMetric === 'rise' ? 'rise' : 'fall';
-    return {
-      queryKey: ['ranking', 'domestic', apiMetric],
-      enabled: regionFilter === '국내' || regionFilter === '전체',
-      queryFn: () => fetchDomesticRanking(apiMetric),
-    };
-  }
-
-  // 해외 미구현
-  if (regionFilter === '해외') {
-    return {
-      queryKey: ['ranking', 'overseas', rankingMetric],
-      enabled: false,
-      queryFn: async () => [],
-      notImplementedMessage: '해외 실시간 순위는 아직 준비 중입니다.',
-    };
-  }
-
-  return {
-    queryKey: ['ranking', regionFilter, 'unknown'],
-    enabled: false,
-    queryFn: async () => [],
-    notImplementedMessage: '선택한 조합은 아직 준비 중입니다.',
-  };
-}
-
 type UseRealtimeStockChartResult = {
-  items: DomesticRankingItem[];
+  items: StockRankingItem[];
   isLoading: boolean;
   isFetching: boolean;
   error: string | null;
@@ -94,11 +38,59 @@ function formatTime(timestamp: number | null | undefined) {
   return `${h}:${m}`;
 }
 
+function resolveRankingQuery(
+  region: string,
+  metricLabel: string
+): ResolvedRankingQuery {
+  const regionFilter: RegionFilter =
+    region === '국내' || region === '해외' ? (region as RegionFilter) : '전체';
+
+  let rankingMetric: RankingMetric | null = null;
+  if (metricLabel.includes('거래대금')) rankingMetric = 'amount';
+  else if (metricLabel.includes('거래량')) rankingMetric = 'volume';
+  else if (metricLabel.includes('급상승')) rankingMetric = 'rise';
+  else if (metricLabel.includes('급하락')) rankingMetric = 'fall';
+
+  if (!rankingMetric) {
+    return {
+      queryKey: ['ranking', regionFilter, 'unknown'],
+      enabled: false,
+      queryFn: async () => [],
+      notImplementedMessage: '선택한 지표는 아직 준비 중입니다.',
+    };
+  }
+
+  if (regionFilter === '국내' || regionFilter === '전체') {
+    const apiMetric: DomesticRankingMetric = rankingMetric;
+    return {
+      queryKey: ['ranking', 'domestic', apiMetric],
+      enabled: true,
+      queryFn: () => fetchDomesticRanking(apiMetric),
+    };
+  }
+
+  if (regionFilter === '해외') {
+    const apiMetric: OverseasRankingMetric = rankingMetric;
+    return {
+      queryKey: ['ranking', 'overseas', apiMetric],
+      enabled: true,
+      queryFn: () => fetchOverseasRanking(apiMetric),
+    };
+  }
+
+  return {
+    queryKey: ['ranking', regionFilter, 'unknown'],
+    enabled: false,
+    queryFn: async () => [],
+    notImplementedMessage: '선택한 조합은 아직 준비 중입니다.',
+  };
+}
+
 export function useRealtimeStockChart(
   region: string,
-  metric: string
+  metricLabel: string
 ): UseRealtimeStockChartResult {
-  const resolved = resolveRankingQuery(region, metric);
+  const resolved = resolveRankingQuery(region, metricLabel);
 
   const {
     data,
@@ -107,7 +99,7 @@ export function useRealtimeStockChart(
     error: queryError,
     dataUpdatedAt,
     refetch,
-  } = useQuery<DomesticRankingItem[], Error>({
+  } = useQuery<StockRankingItem[], Error>({
     queryKey: resolved.queryKey,
     queryFn: resolved.queryFn,
     enabled: resolved.enabled,

--- a/services/kisRankingClient.ts
+++ b/services/kisRankingClient.ts
@@ -1,7 +1,7 @@
-export type DomesticRankingMetric = 'volume' | 'amount';
+export type DomesticRankingMetric = 'volume' | 'amount' | 'rise' | 'fall';
 
 export type DomesticRankingItem = {
-  code: string; // 종목코드
+  code: string; // 종목코드 (KIS의 mksc_shrn_iscd / stck_shrn_iscd 통합)
   name: string; // 종목명(한글)
   price: number; // 현재가
   changeRate: number; // 등락률 (%)
@@ -10,10 +10,31 @@ export type DomesticRankingItem = {
   prevVolume: number; // 전일 거래량
 };
 
-type ApiResponse = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  output: any[];
+// KIS 랭킹 API 공통 row 타입
+type KISRankingRow = {
+  mksc_shrn_iscd?: string; // 거래량/거래대금 랭킹에서 사용
+  stck_shrn_iscd?: string; // 등락률 랭킹에서 사용
+  hts_kor_isnm: string;
+  stck_prpr: string | number;
+  prdy_ctrt: string | number;
+  acml_vol: string | number;
+  acml_tr_pbmn: string | number;
+  prdy_vol: string | number;
 };
+
+type ApiResponse = {
+  output?: KISRankingRow[];
+};
+
+// 거래량/거래대금 랭킹: mksc_shrn_iscd
+// 등락률 랭킹: stck_shrn_iscd
+function getShortCode(row: KISRankingRow): string {
+  const code = row.mksc_shrn_iscd ?? row.stck_shrn_iscd;
+  if (!code) {
+    throw new Error('KIS ranking row is missing stock short code');
+  }
+  return code;
+}
 
 export async function fetchDomesticRanking(
   metric: DomesticRankingMetric = 'volume'
@@ -28,11 +49,11 @@ export async function fetchDomesticRanking(
   }
 
   const data = (await res.json()) as ApiResponse;
-  console.log(data);
+
   if (!data.output) return [];
 
   return data.output.map((row) => ({
-    code: row.mksc_shrn_iscd, // 단축코드
+    code: getShortCode(row),
     name: row.hts_kor_isnm, // 종목명
     price: Number(row.stck_prpr), // 현재가
     changeRate: Number(row.prdy_ctrt), // 등락률

--- a/services/kisRankingClient.ts
+++ b/services/kisRankingClient.ts
@@ -62,3 +62,47 @@ export async function fetchDomesticRanking(
     prevVolume: Number(row.prdy_vol), // 전일 거래량
   }));
 }
+
+export type OverseasRankingMetric = DomesticRankingMetric;
+export type OverseasRankingItem = DomesticRankingItem;
+
+type KISOverseasRankingRow = {
+  symb: string; // 종목코드
+  name: string; // 종목명
+  last: string | number; // 현재가
+  rate: string | number; // 등락율
+  tvol: string | number; // 거래량
+  tamt?: string | number; // 거래대금 (없는 API도 있어서 optional)
+  n_tvol?: string | number; // 기준/평균 거래량 (증가율/회전율에서 optional)
+};
+
+type OverseasApiResponse = {
+  output2?: KISOverseasRankingRow[];
+};
+
+export async function fetchOverseasRanking(
+  metric: OverseasRankingMetric = 'volume'
+): Promise<OverseasRankingItem[]> {
+  const res = await fetch(`/api/kis/ranking/overseas?metric=${metric}`, {
+    method: 'GET',
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`KIS overseas ranking error: ${text}`);
+  }
+
+  const data = (await res.json()) as OverseasApiResponse;
+
+  const rows = data.output2 ?? [];
+
+  return rows.map((row) => ({
+    code: row.symb,
+    name: row.name,
+    price: Number(row.last),
+    changeRate: Number(row.rate),
+    volume: Number(row.tvol),
+    amount: Number(row.tamt ?? 0),
+    prevVolume: Number(row.n_tvol ?? 0),
+  }));
+}


### PR DESCRIPTION
## 📝 변경 사항

1. 국내·해외 실시간 랭킹 API 연동
2. 실시간 종목 차트 전체(국내+해외) 로직 추가
3. KISFetchClient 도입으로 KIS API 요청 로직 공통화

## 🔍 변경 사항 세부 설명

## 📷 스크린샷 (선택)

## 🕵️‍♀️ 요청사항 (선택)
- 환경 변수 구조 변경으로 인한 env 재설정 필요