### PR TITLE
feat: 관심탭 실시간 동기화 기능 구현

### DIFF
--- a/components/side-bar/FavoritesPanel.tsx
+++ b/components/side-bar/FavoritesPanel.tsx
@@ -6,7 +6,6 @@ import { useFavoriteStock } from '@/hooks/useFavoriteStock';
 import { useRealtimePrice } from '@/hooks/useRealtimePrice';
 import type { MarketType } from '@/lib/kis/KISRealtimePriceManager';
 import { Heart } from 'lucide-react';
-import ChangeRateCell from '../main/ChangeRateCell';
 
 export default function FavoritesPanel() {
   const [user, setUser] = useState<AuthUser>(null);
@@ -145,7 +144,15 @@ export default function FavoritesPanel() {
                     )}
                     {displayChangeRate != null && (
                       <div className="mt-1">
-                        <ChangeRateCell value={displayChangeRate} />
+                        <div
+                          className={`text-sm ${
+                            (displayChangeRate ?? 0) >= 0
+                              ? 'text-red-500'
+                              : 'text-blue-500'
+                          }`}
+                        >
+                          {displayChangeRate}%
+                        </div>
                       </div>
                     )}
                   </div>

--- a/hooks/useFavoriteStock.ts
+++ b/hooks/useFavoriteStock.ts
@@ -15,6 +15,13 @@ export type FavoriteStock = {
 const buildStorageKey = (userKey: string | null) =>
   userKey ? `stockdodo:favorites:${userKey}` : null;
 
+const FAVORITES_EVENT = 'stockdodo:favorites-changed';
+
+type FavoritesEventDetail = {
+  storageKey: string;
+  favorites: FavoriteStock[];
+};
+
 export function useFavoriteStock(userKey: string | null) {
   const storageKey = buildStorageKey(userKey);
   const [favorites, setFavorites] = useState<FavoriteStock[]>([]);
@@ -38,7 +45,6 @@ export function useFavoriteStock(userKey: string | null) {
     }
   }, [storageKey]);
 
-  // 변경사항 저장
   useEffect(() => {
     if (!storageKey) return;
     if (!hydrated) return;
@@ -50,25 +56,58 @@ export function useFavoriteStock(userKey: string | null) {
     }
   }, [storageKey, favorites, hydrated]);
 
+  useEffect(() => {
+    if (!storageKey) return;
+    if (typeof window === 'undefined') return;
+
+    const handler = (event: Event) => {
+      const custom = event as CustomEvent<FavoritesEventDetail>;
+      if (custom.detail.storageKey !== storageKey) return;
+
+      setTimeout(() => {
+        setFavorites(custom.detail.favorites);
+      }, 0);
+    };
+
+    window.addEventListener(FAVORITES_EVENT, handler);
+    return () => {
+      window.removeEventListener(FAVORITES_EVENT, handler);
+    };
+  }, [storageKey]);
+
   const isFavorite = (code: string) =>
     favorites.some((item) => item.code === code);
+
+  const broadcast = (next: FavoriteStock[]) => {
+    if (typeof window === 'undefined' || !storageKey) return;
+    const event = new CustomEvent<FavoritesEventDetail>(FAVORITES_EVENT, {
+      detail: { storageKey, favorites: next },
+    });
+    window.dispatchEvent(event);
+  };
 
   const toggleFavorite = (stock: FavoriteStock) => {
     if (!storageKey) return;
 
     setFavorites((prev) => {
       const exists = prev.some((item) => item.code === stock.code);
-      if (exists) {
-        return prev.filter((item) => item.code !== stock.code);
-      }
-      return [...prev, stock];
+      const next = exists
+        ? prev.filter((item) => item.code !== stock.code)
+        : [...prev, stock];
+
+      broadcast(next);
+      return next;
     });
   };
 
   const removeFavorite = (code: string) => {
     if (!storageKey) return;
 
-    setFavorites((prev) => prev.filter((item) => item.code !== code));
+    setFavorites((prev) => {
+      const next = prev.filter((item) => item.code !== code);
+      broadcast(next);
+      return next;
+    });
   };
 
   return { favorites, isFavorite, toggleFavorite, removeFavorite, hydrated };


### PR DESCRIPTION
## 📝 변경 사항

1. 관심종목 상태를 새로고침 없이 실시간 반영하도록 개선

## 🔍 변경 사항 세부 설명

1. 메인 테이블에서 관심종목 변경 시 사이드바 FavoritesPanel에 즉시 반영
2. 브라우저 이벤트 기반으로 useFavoriteStock 훅 간 상태 공유 처리
3. 새로고침 없이 관심 상태가 일관되게 유지되도록 UX 개선

## 📷 스크린샷 (선택)
![화면 기록 2025-12-05 오후 1 45 42](https://github.com/user-attachments/assets/4e478a8e-64c1-4554-a82d-6e9677dd45e5)
## 🕵️‍♀️ 요청사항 (선택)
